### PR TITLE
Add media attribute to print.css link element

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <link href="//fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet">
 
     <link href="css/style.css" rel="stylesheet">
-    <link href="css/print.css" rel="stylesheet">
+    <link href="css/print.css" rel="stylesheet" media="print">
 
     <script>
       (function(w,g){w['GoogleAnalyticsObject']=g;


### PR DESCRIPTION
I add this to remove print.css from Critical Rendering Path.